### PR TITLE
Inventory & Chest Compatibility Update

### DIFF
--- a/CoCEd/ViewModel/GameVM.Core.cs
+++ b/CoCEd/ViewModel/GameVM.Core.cs
@@ -239,7 +239,14 @@ namespace CoCEd.ViewModel
         void UpdateChest()
         {
             _chest.Clear();
-            foreach (var pair in GetObj("itemStorage")) _chest.Add(pair.ValueAsObject);
+            if (GetObj("itemStorage") != null)
+            {
+                foreach (var pair in GetObj("itemStorage")) _chest.Add(pair.ValueAsObject);
+            }
+            else if (GetObj("inventory").GetObj("itemStorage") != null)
+            {
+                foreach (var pair in GetObj("inventory").GetObj("itemStorage")) _chest.Add(pair.ValueAsObject);
+            }
         }
 
         void UpdateWeaponRack() // gearStorage [0, 8]

--- a/CoCEd/ViewModel/GameVM.Core.cs
+++ b/CoCEd/ViewModel/GameVM.Core.cs
@@ -177,7 +177,7 @@ namespace CoCEd.ViewModel
                 case "Camp - Ornate Chest":
                     if (IsRevamp || name == "Camp - Chest")
                     {
-                        var array = GetObj("itemStorage"); // max chest slots are 6 in CoC and 14 in CoC-Revamp-Mod
+                        var array = GetItemStorageObj(); // max chest slots are 6 in CoC and 14 in CoC-Revamp-Mod
                         int count = name == "Camp - Chest" ? 6 : 4; // the CoC-Revamp-Mod addon chests add 4 slots a piece
                         if (isOwned)
                         {
@@ -236,17 +236,16 @@ namespace CoCEd.ViewModel
             }
         }
 
+        AmfObject GetItemStorageObj()
+        {
+            var itemStorage = GetObj("itemStorage");
+            return itemStorage != null ? itemStorage : GetObj("inventory").GetObj("itemStorage");
+        }
+
         void UpdateChest()
         {
             _chest.Clear();
-            if (GetObj("itemStorage") != null)
-            {
-                foreach (var pair in GetObj("itemStorage")) _chest.Add(pair.ValueAsObject);
-            }
-            else if (GetObj("inventory").GetObj("itemStorage") != null)
-            {
-                foreach (var pair in GetObj("inventory").GetObj("itemStorage")) _chest.Add(pair.ValueAsObject);
-            }
+            foreach (var pair in GetItemStorageObj()) _chest.Add(pair.ValueAsObject);
         }
 
         void UpdateWeaponRack() // gearStorage [0, 8]

--- a/CoCEd/ViewModel/GameVM.Core.cs
+++ b/CoCEd/ViewModel/GameVM.Core.cs
@@ -225,14 +225,22 @@ namespace CoCEd.ViewModel
             }
         }
 
+        //Not sure how I can make the code better as I can't apply the same trick to chest without complicating the code further.
         void UpdateInventory()
         {
             _inventory.Clear();
             int count = IsRevamp ? 10 : 5; // max inventory slots are 5 in CoC and 10 in CoC-Revamp-Mod
-            for (int i = 0; i < count; i++)
+            if (GetObj("itemSlots") != null) //For serialized saves.
             {
-                var slot = GetObj("itemSlot" + (i + 1));
-                if (slot != null && slot.GetBool("unlocked")) _inventory.Add(slot);
+                foreach (var pair in GetObj("itemSlots")) _inventory.Add(pair.ValueAsObject);
+            }
+            else //For legacy item slots used in Vanilla and Revamp 1.4.15-pre. 
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    var slot = GetObj("itemSlot" + (i + 1));
+                    if (slot != null && slot.GetBool("unlocked")) _inventory.Add(slot);
+                }
             }
         }
 


### PR DESCRIPTION
Should fix the crash when attempting to load modded save in 1.4.15+.

Tested with 1.4.17 save and it should now work. Saving works as well.

Compatibility should be retained. Took the suggestions in mind. Inventory update to be followed.
This time, I'm using the correct branch since I cannot change the source branch.

One issue is being unsure how I would make the code better for inventory.